### PR TITLE
Add color mode controls, value bar, and visual improvements

### DIFF
--- a/compact-light-card.js
+++ b/compact-light-card.js
@@ -8,7 +8,7 @@
  */
 
 
-console.log("compact-light-card.js v0.6.60 loaded!");
+console.log("compact-light-card.js v0.7.01 loaded!");
 window.left_offset = 66;
 
 class CompactLightCard extends HTMLElement {
@@ -202,21 +202,23 @@ class CompactLightCard extends HTMLElement {
         }
 
         .secondary-icon {
-          --mdc-icon-size: 24px;
+          --mdc-icon-size: 20px;
           color: var(--primary-text-color);
           pointer-events: auto;
           cursor: pointer;
-          opacity: 0.7;
-          transition: opacity 0.2s ease;
+          padding: 4px;
+          border-radius: 50%;
+          opacity: 0.5;
+          transition: opacity 0.2s ease, background 0.2s ease;
         }
 
         .secondary-icon:hover {
-          opacity: 1;
+          opacity: 0.8;
         }
 
         .secondary-icon.on {
           opacity: 1;
-          color: var(--primary-color, #03a9f4);
+          background: rgba(255, 255, 255, 0.2);
         }
 
         .secondary-icon.hidden {
@@ -224,9 +226,8 @@ class CompactLightCard extends HTMLElement {
         }
 
         .secondary-icon.swapped {
-          background: rgba(255, 255, 255, 0.15);
-          border-radius: 50%;
-          padding: 2px;
+          opacity: 1;
+          background: rgba(255, 255, 255, 0.2);
         }
 
         .mode-buttons {

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "domain": "compact_light_card",
   "name": "Compact Light Card",
   "documentation": "https://github.com/lewisburgess/compact-light-card",
-  "version": "0.6.60",
+  "version": "0.7.01",
   "dependencies": [],
   "codeowners": ["@lewisburgess"],
   "requirements": []


### PR DESCRIPTION
## Summary

This PR adds several new features and improvements to the Compact Light Card:

### New Features
- **Color Temperature & RGB Mode Controls**: Toggle buttons to switch between brightness, color temp (Kelvin), and RGB hue control with gradient sliders
- **Show Value Bar Option**: Optional solid background behind buttons displaying the current value
- **Icon Tap to Brightness**: Turn on light to a specific brightness when tapping the icon
- **Icon Background Colour**: Set icon background independently from the light's colour
- **Separate Opacity Controls**: Different opacity for card/icon in on/off states

### Visual Improvements
- White position marker for color temp/RGB modes with gradient backgrounds
- Consistent slider positioning
- Brightness bar has straight right edge at 100%
- Fixed percentage display bouncing with min-width
- Value shows correctly on load (Kelvin/degrees/%) instead of "-"
- Visual delimiter between slider and button area when value bar is enabled

### Bug Fixes
- Input fields no longer defocus when typing hex colours
- Entity picker and icon picker now show currently selected values

### Visual Editor
- All new options available in the visual editor
- Entity picker with autocomplete (filtered to lights)
- Icon picker with search and preview
- Color pickers synced with hex text inputs
- Opacity sliders with visual preview

### Documentation
- Reorganized into logical sections
- Added color mode controls documentation
- Added opacity priority table
- Full example configuration

## Test Plan
- [ ] Test brightness slider on dimmable light
- [ ] Test color temp slider on light with color temp support
- [ ] Test RGB/hue slider on color-capable light
- [ ] Test show_value_bar option on/off
- [ ] Test icon_tap_to_brightness feature
- [ ] Verify visual editor shows all options correctly

🤖 Generated with [Claude Code](https://claude.ai/code)